### PR TITLE
PARITY seems to be easy to program in RASP when it is thought to be hard for Transformer encoders to learn? (let's add the examples and the question to our repo, in Weiss and Tracr RASP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Solving little problems in Restricted Access Sequence Processing (RASP), a language designed to help one in "Thinking Like Transformers" (title of Weiss et al 2021 paper which introduced it). Hoping to use RASP for a final project in a class this year (2024 Nov) so trying to keep myself accountable by working through problems in a repo. 
+
+Programs in this folder can be interpreted using Weiss et al 2021's RASP interpreter at https://github.com/tech-srl/RASP .

--- a/tracr-programs/README.md
+++ b/tracr-programs/README.md
@@ -1,0 +1,3 @@
+Programs in this folder require DeepMind's Tracr compiler for RASP (does not support all RASP functionality in Weiss' original RASP or their interpreter).
+
+See https://github.com/google-deepmind/tracr .

--- a/tracr-programs/parity-for-constant-length-sequences.py
+++ b/tracr-programs/parity-for-constant-length-sequences.py
@@ -1,0 +1,110 @@
+# Show PARITY for fixed length input can be coded this way
+# Interesting: It is very easy to program the PARITY task in Tracr compatible RASP,
+# where RASP intends to model the computational capabilities of Transformer encoders,
+# but Transformer encoders are not generally regarded as being able to actually
+# learn to solve PARITY
+# (unlike a feedforward neural network in general as
+# Chiang and Cholak 2022 ( https://arxiv.org/abs/2202.12172 ) note that
+# Rumelhart 1986 showed).
+# Definition of PARITY per Strobl et al 2024
+# ( https://arxiv.org/abs/2311.00208 ):
+# "The classic examples of languages not in AC0 are PARITY and MAJORITY.
+# The language PARITY ⊆ {0, 1}∗ contains all bit strings
+# containing an odd number of 1’s, and MAJORITY ⊆ {0, 1}∗ consists of
+# all bit strings in which more than half of the bits are 1’s."
+# With intermediate decoder steps Transformers are Turing complete and
+# can definitely solve Parity (though it is even then hard to train,
+# see Zhou et al 2024 ( https://arxiv.org/abs/2310.16028 )
+# who modify RASP to get learnable RASP (RASP-L) and
+# apply RASP-L to autoregressive decoder with scratchpad),
+# but RASP per Weiss 2021 ( https://arxiv.org/abs/2106.06981 )
+# originally models an encoder WITHOUT a decoder
+# loop/scratchpad/chain of thought and RASP solves PARITY easily.
+# Strobl et al 2024 note that "Average-hard and softmax attention"
+# as opposed to hard attention enable counting
+# "which can be used to solve problems like MAJORITY that are outside AC0"
+# (like PARITY as well), but
+# Chiang and Cholak (2022) ( https://arxiv.org/abs/2202.12172 )  show that
+# while they theoretically can implement parity with a Transformer encoder
+# they could NOT train a Transformer to learn it,
+# and Zhou et al 2024 also excluded RASP operations when defining their
+# RASP-L (Learnable RASP) such that parity was not solvable
+# without modification even with a decoder loop.
+# Deletang et al 2023 ( https://arxiv.org/abs/2207.02098 )
+# also find that "transformers learn MAJORITY, but not PARITY."
+
+from tracr.rasp import rasp
+length_constant = 10
+# can't do the operation that works in Weiss RASP, need to adapt to a Tracr compatible way
+# In Weiss' RASP: `parity = selector_width(select(tokens, "1", ==)) % 2;`
+# but cannot have "1" or 1 as 2nd argument in Tracr select;
+# also cannot aggregate to get fraction of ones and multiply by length does not work due to numerical stability in Tracr (not in RASP interpreter from Weiss) (multiplying 0.30 by 10 for example gives 3.33 in Tracr)
+# turns out the Tracr preferred way is to define a lambda to use as the comparator and ignore the 2nd argument:
+ones_selector = rasp.Select(rasp.tokens, rasp.tokens, lambda k, q: k == 1)
+count_ones = rasp.SelectorWidth(ones_selector)
+
+parity = rasp.Map(lambda x: x % 2, count_ones)
+
+from tracr.compiler import compiling
+
+bos = "BOS"
+pad = "PAD"
+
+model_count_ones = compiling.compile_rasp_to_model(
+    count_ones,
+    vocab={0, 1},
+    max_seq_len=int(length_constant),
+    compiler_bos=bos,
+    compiler_pad=pad,
+)
+
+model_parity = compiling.compile_rasp_to_model(
+    parity,
+    vocab={0, 1},
+    max_seq_len=int(length_constant),
+    compiler_bos=bos,
+    compiler_pad=pad
+)
+
+# Show PARITY for fixed length input can be coded this way
+# should handle sequences up to length "length_constant" - 1
+
+# Some examples
+sequence = [1, 0,0,0,1]
+output = model_parity.apply([bos] + sequence).decoded
+print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")
+# ['BOS', 0, 0, 0, 0, 0]
+
+sequence = [1, 0,1,0,1]
+output = model_parity.apply([bos] + sequence).decoded
+print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")
+# ['BOS', 1, 1, 1, 1, 1]
+
+sequence = [1, 1,0,1,1]
+output = model_parity.apply([bos] + sequence).decoded
+print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")
+# ['BOS', 0, 0, 0, 0, 0]
+
+sequence = [0, 1,1,1,0]
+output = model_parity.apply([bos] + sequence).decoded
+print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")
+# ['BOS', 1, 1, 1, 1, 1]
+
+sequence = [1, 0,0,0,0]
+output = model_parity.apply([bos] + sequence).decoded
+print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")
+# ['BOS', 1, 1, 1, 1, 1]
+
+sequence = [0, 0,0,0,0]
+output = model_parity.apply([bos] + sequence).decoded
+print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")
+# ['BOS', 0, 0, 0, 0, 0]
+
+sequence = []
+for idx in range(int(length_constant - 1)):
+    sequence.append(1)
+    inp = [bos] + sequence
+    output = model_parity.apply(inp).decoded
+    output_count_ones = model_count_ones.apply(inp).decoded
+    print(f"Transformer model computes count of ones of {sequence} as {output_count_ones}")
+    print(f"Transformer model computes PARITY of {sequence} as {output} (take any position after first in output sequence as answer)")

--- a/why-is-parity-so-easy-to-program-in-rasp-when-hard-for-transformers-to-learn.rasp
+++ b/why-is-parity-so-easy-to-program-in-rasp-when-hard-for-transformers-to-learn.rasp
@@ -1,12 +1,44 @@
-# Interesting: It is very easy to program the PARITY task in RASP, where RASP is supposed to model the computational capabilities of Transformers, and Transformers are not generally regarded as being able to actually learn to solve PARITY (unlike a feedforward neural network in general as Chiang and Cholak 2022 ( https://arxiv.org/abs/2202.12172 ) note that Rumelhart 1986 showed).
-# Definition of PARITY per Strobl et al 2024 ( https://arxiv.org/abs/2311.00208 ):
-# "The classic examples of languages not in AC0 are PARITY and MAJORITY. The language PARITY ⊆ {0, 1}∗ contains all bit strings containing an odd number of 1’s, and MAJORITY ⊆ {0, 1}∗ consists of all bit strings in which more than half of the bits are 1’s."
-# With intermediate steps Transformers are Turing complete and can definitely solve Parity (though it is even then hard to train, see Zhou et al 2024 ( https://arxiv.org/abs/2310.16028 ) who modify RASP to get learnable RASP ), but RASP per Weiss 2021 ( https://arxiv.org/abs/2106.06981 ) originally models an encoder without a decoder loop/scratchpad/chain of thought and solves PARITY easily.
-# Strobl et al 2024 note that "Average-hard and softmax attention" as opposed to hard attention enable counting "which can be used to solve problems like MAJORITY that are outside AC0" (like PARITY as well), but Chiang and Cholak (2022) ( https://arxiv.org/abs/2202.12172 )  show that while they theoretically can implement parity with a Transformer they could not train a Transformer to learn it, and Zhou et al 2024 also excluded RASP operations when defining their RASP-L (Learnable RASP) such that parity was not solvable without modification or a decoder loop. Deletang et al 2023 ( https://arxiv.org/abs/2207.02098 ) also find that "transformers learn MAJORITY, but not PARITY."
+# Interesting: It is very easy to program the PARITY task in RASP,
+# where RASP intends to model the computational capabilities of Transformer encoders,
+# but Transformer encoders are not generally regarded as being able to actually
+# learn to solve PARITY
+# (unlike a feedforward neural network in general as
+# Chiang and Cholak 2022 ( https://arxiv.org/abs/2202.12172 ) note that
+# Rumelhart 1986 showed).
+# Definition of PARITY per Strobl et al 2024
+# ( https://arxiv.org/abs/2311.00208 ):
+# "The classic examples of languages not in AC0 are PARITY and MAJORITY.
+# The language PARITY ⊆ {0, 1}∗ contains all bit strings
+# containing an odd number of 1’s, and MAJORITY ⊆ {0, 1}∗ consists of
+# all bit strings in which more than half of the bits are 1’s."
+# With intermediate decoder steps Transformers are Turing complete and
+# can definitely solve Parity (though it is even then hard to train,
+# see Zhou et al 2024 ( https://arxiv.org/abs/2310.16028 )
+# who modify RASP to get learnable RASP (RASP-L) and
+# apply RASP-L to autoregressive decoder with scratchpad),
+# but RASP per Weiss 2021 ( https://arxiv.org/abs/2106.06981 )
+# originally models an encoder WITHOUT a decoder
+# loop/scratchpad/chain of thought and RASP solves PARITY easily.
+# Strobl et al 2024 note that "Average-hard and softmax attention"
+# as opposed to hard attention enable counting
+# "which can be used to solve problems like MAJORITY that are outside AC0"
+# (like PARITY as well), but
+# Chiang and Cholak (2022) ( https://arxiv.org/abs/2202.12172 )  show that
+# while they theoretically can implement parity with a Transformer encoder
+# they could NOT train a Transformer to learn it,
+# and Zhou et al 2024 also excluded RASP operations when defining their
+# RASP-L (Learnable RASP) such that parity was not solvable
+# without modification even with a decoder loop.
+# Deletang et al 2023 ( https://arxiv.org/abs/2207.02098 )
+# also find that "transformers learn MAJORITY, but not PARITY."
 
-# In any case, using the RASP "selector_width" operation on a selector matchng ones followed by an elementwise modulus, 
-# it appears Parity can be easily solved in RASP since one can cause the entire sequence to be equal to the number of ones
-# and then do a elementwise modulo 2 operation so that the parity (1 if odd number of 1s, 0 otherwise) is presented in all digits of the output sequence identically.
+# In any case, using the RASP "selector_width" operation on a
+# selector matchng ones followed by an elementwise modulus,
+# it appears Parity can be easily solved in RASP since one can cause the
+# entire sequence to be equal to the number of ones
+# and then do a elementwise modulo 2 operation so that the parity
+# (1 if odd number of 1s, 0 otherwise) is presented in all digits
+# of the output sequence identically.
 
 # e.g.
 

--- a/why-is-parity-so-easy-to-program-in-rasp-when-hard-for-transformers-to-learn.rasp
+++ b/why-is-parity-so-easy-to-program-in-rasp-when-hard-for-transformers-to-learn.rasp
@@ -1,0 +1,37 @@
+# Interesting: It is very easy to program the PARITY task in RASP, where RASP is supposed to model the computational capabilities of Transformers, and Transformers are not generally regarded as being able to actually learn to solve PARITY (unlike a feedforward neural network in general as Chiang and Cholak 2022 ( https://arxiv.org/abs/2202.12172 ) note that Rumelhart 1986 showed).
+# Definition of PARITY per Strobl et al 2024 ( https://arxiv.org/abs/2311.00208 ):
+# "The classic examples of languages not in AC0 are PARITY and MAJORITY. The language PARITY ⊆ {0, 1}∗ contains all bit strings containing an odd number of 1’s, and MAJORITY ⊆ {0, 1}∗ consists of all bit strings in which more than half of the bits are 1’s."
+# With intermediate steps Transformers are Turing complete and can definitely solve Parity (though it is even then hard to train, see Zhou et al 2024 ( https://arxiv.org/abs/2310.16028 ) who modify RASP to get learnable RASP ), but RASP per Weiss 2021 ( https://arxiv.org/abs/2106.06981 ) originally models an encoder without a decoder loop/scratchpad/chain of thought and solves PARITY easily.
+# Strobl et al 2024 note that "Average-hard and softmax attention" as opposed to hard attention enable counting "which can be used to solve problems like MAJORITY that are outside AC0" (like PARITY as well), but Chiang and Cholak (2022) ( https://arxiv.org/abs/2202.12172 )  show that while they theoretically can implement parity with a Transformer they could not train a Transformer to learn it, and Zhou et al 2024 also excluded RASP operations when defining their RASP-L (Learnable RASP) such that parity was not solvable without modification or a decoder loop. Deletang et al 2023 ( https://arxiv.org/abs/2207.02098 ) also find that "transformers learn MAJORITY, but not PARITY."
+
+# In any case, using the RASP "selector_width" operation on a selector matchng ones followed by an elementwise modulus, 
+# it appears Parity can be easily solved in RASP since one can cause the entire sequence to be equal to the number of ones
+# and then do a elementwise modulo 2 operation so that the parity (1 if odd number of 1s, 0 otherwise) is presented in all digits of the output sequence identically.
+
+# e.g.
+
+set example "100100010000" # three 1's => output 1
+parity = selector_width(select(tokens, "1", ==)) % 2;
+#     s-op: parity
+#         Example: parity("100100010000") = [1]*12 (ints)
+
+set example "100100010010" # four 1's => output 0
+parity = selector_width(select(tokens, "1", ==)) % 2;
+#     s-op: parity
+#         Example: parity("100100010010") = [0]*12 (ints)
+
+# five 1's => output 1
+set example "1001000100101"
+parity;
+#     s-op: parity
+#         Example: parity("1001000100101") = [1]*13 (ints)
+
+# six 1's => output 0
+set example "10010001001011"
+parity;
+#     s-op: parity
+#         Example: parity("10010001001011") = [0]*14 (ints)
+
+# and so forth
+
+# read any output sequence symbol (they are all identical) and one gets the answer.


### PR DESCRIPTION
Interesting: It is very easy to program the PARITY task in RASP,
where RASP intends to model the computational capabilities of Transformer encoders,
but Transformer encoders are not generally regarded as being able to actually
learn to solve PARITY
(unlike a feedforward neural network in general as
Chiang and Cholak 2022 ( https://arxiv.org/abs/2202.12172 ) note that
Rumelhart 1986 showed).
Definition of PARITY per Strobl et al 2024
( https://arxiv.org/abs/2311.00208 ):
"The classic examples of languages not in AC0 are PARITY and MAJORITY.
The language PARITY ⊆ {0, 1}∗ contains all bit strings
containing an odd number of 1’s, and MAJORITY ⊆ {0, 1}∗ consists of
all bit strings in which more than half of the bits are 1’s."
With intermediate decoder steps Transformers are Turing complete and
can definitely solve Parity (though it is even then hard to train,
see Zhou et al 2024 ( https://arxiv.org/abs/2310.16028 )
who modify RASP to get learnable RASP (RASP-L) and
apply RASP-L to autoregressive decoder with scratchpad),
but RASP per Weiss 2021 ( https://arxiv.org/abs/2106.06981 )
originally models an encoder WITHOUT a decoder
loop/scratchpad/chain of thought and RASP solves PARITY easily.
Strobl et al 2024 note that "Average-hard and softmax attention"
as opposed to hard attention enable counting
"which can be used to solve problems like MAJORITY that are outside AC0"
(like PARITY as well), but
Chiang and Cholak (2022) ( https://arxiv.org/abs/2202.12172 )  show that
while they theoretically can implement parity with a Transformer encoder
they could NOT train a Transformer to learn it,
and Zhou et al 2024 also excluded RASP operations when defining their
RASP-L (Learnable RASP) such that parity was not solvable
without modification even with a decoder loop.
Deletang et al 2023 ( https://arxiv.org/abs/2207.02098 )
also find that "transformers learn MAJORITY, but not PARITY."

In any case, using the RASP "selector_width" operation on a
selector matchng ones followed by an elementwise modulus,
it appears Parity can be easily solved in RASP since one can cause the
entire sequence to be equal to the number of ones
and then do a elementwise modulo 2 operation so that the parity
(1 if odd number of 1s, 0 otherwise) is presented in all digits
of the output sequence identically.